### PR TITLE
MediaType over MediaTag

### DIFF
--- a/openapi/generator.go
+++ b/openapi/generator.go
@@ -1063,7 +1063,7 @@ func (g *Generator) flattenStructSchema(t, parent reflect.Type, schema *Schema, 
 			schema.Required = append(schema.Required, fname)
 			sort.Strings(schema.Required)
 		}
-		sfs := g.newSchemaFromStructField(f, required, fname, t, mediaTag)
+		sfs := g.newSchemaFromStructField(f, required, fname, t, mediaType)
 		if sfs != nil {
 			schema.Properties[fname] = sfs
 		}


### PR DESCRIPTION
This caused recusive model building to break since the media type is expected over the tag